### PR TITLE
Temporary security configurations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Resumo do PR:
+
+> Insira a resumo aqui...
+
+## Descrição/Objetivo do PR
+
+> Foi feita uma requisição para uma...
+
+## Tíquetes
+
+> Insira os link's aqui Exemplo: feature-lista
+
+## Risco do PR
+
+**Marque opção abaixo: Exemplo: [X]**
+
+- [ ] - Alto
+- [ ] - Médio
+- [ ] - Baixo
+
+Qual motivo: Essa mudança irá impactar...
+
+## Tipo de Mudança
+
+**Marque opção abaixo: Exemplo: [X]**
+
+- [ ] - feat (new feature)
+- [ ] - fix (bug fix)
+- [ ] - docs (changes to documentation)
+- [ ] - style (formatting, missing semi colons, etc; no code change)

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
@@ -59,6 +63,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/taskconnect/serviceprovider/security/SecurityConfig.java
+++ b/src/main/java/com/taskconnect/serviceprovider/security/SecurityConfig.java
@@ -2,8 +2,14 @@ package com.taskconnect.serviceprovider.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 public class SecurityConfig {
@@ -11,14 +17,26 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // CSRF is disabled for early stages of the project. This might change later.
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                // By default, withDefaults() uses a Bean by the name of corsConfigurationSource.
+                .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(request ->
                         request
-                                // Authorization will be properly set when roles and authorities are defined.
+                                // Any request is being authorized as there's no authentication mechanism implemented.
                                 .anyRequest().permitAll())
-                .formLogin(form -> form.disable());
+                .formLogin(form -> form.disable())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                // There's no login, so there's no need to keep CSRF activated, as it is by default.
+                .csrf(csrf -> csrf.disable());
         return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/taskconnect/serviceprovider/security/SecurityConfig.java
+++ b/src/main/java/com/taskconnect/serviceprovider/security/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.taskconnect.serviceprovider.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF is disabled for early stages of the project. This might change later.
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .authorizeHttpRequests(request ->
+                        request
+                                // Authorization will be properly set when roles and authorities are defined.
+                                .anyRequest().permitAll())
+                .formLogin(form -> form.disable());
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ spring.datasource.password=password
 
 #---
 spring.config.activate.on-profile=test
+spring.jpa.properties.javax.persistence.validation.mode=none
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2
 spring.datasource.url=jdbc:h2:mem:tkcn_service_provider

--- a/src/test/java/com/taskconnect/serviceprovider/security/SecurityConfigTests.java
+++ b/src/test/java/com/taskconnect/serviceprovider/security/SecurityConfigTests.java
@@ -1,0 +1,31 @@
+package com.taskconnect.serviceprovider.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SecurityConfigTests {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final String requestPath = "/api/v1/service-providers";
+
+    @Test
+    public void should_GetResponse_When_RequestedFromCrossOrigin() throws Exception {
+        // When
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.options(requestPath)
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Origin", "http://localhost:3000"));
+
+        // Then
+        result.andDo(MockMvcResultHandlers.print()).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}


### PR DESCRIPTION
Temporarily allow any request to be made to the exposed endpoints until servers, authorities, and roles are defined. This change is important in order for the front-end framework to be able to call the back-end end-points without complaining about CORS.